### PR TITLE
feat: implement fine-grained traits

### DIFF
--- a/src/bin/lambda/delete-product.rs
+++ b/src/bin/lambda/delete-product.rs
@@ -10,8 +10,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     // Initialize logger
     setup_tracing();
 
-    // Initialize service
-    let service = get_crud_service().await;
+    // Initialize store
+    let store = get_store().await;
 
     // Run the Lambda function
     //
@@ -22,14 +22,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
-    // pass a service to a lambda function.
+    // pass a store to a lambda function.
     //
     // Furthermore, we don't await the result of `delete_product` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
     lambda_runtime::run(handler(|event: Request, ctx: Context| {
-        delete_product(&service, event, ctx)
+        delete_product(&store, event, ctx)
     }))
     .await?;
     Ok(())

--- a/src/bin/lambda/dynamodb-streams.rs
+++ b/src/bin/lambda/dynamodb-streams.rs
@@ -9,8 +9,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     // Initialize logger
     setup_tracing();
 
-    // Initialize service
-    let service = get_event_service().await;
+    // Initialize event bus
+    let event_bus = get_event_bus().await;
 
     // Run the Lambda function
     //
@@ -21,14 +21,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
-    // pass a service to a lambda function.
+    // pass the event bus to a lambda function.
     //
     // Furthermore, we don't await the result of `delete_product` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
     lambda_runtime::run(handler_fn(|event: DynamoDBEvent, ctx: Context| {
-        parse_events(&service, event, ctx)
+        parse_events(&event_bus, event, ctx)
     }))
     .await?;
     Ok(())

--- a/src/bin/lambda/get-product.rs
+++ b/src/bin/lambda/get-product.rs
@@ -12,8 +12,8 @@ async fn main() -> Result<(), E> {
     // Initialize logger
     setup_tracing();
 
-    // Initialize service
-    let service = get_crud_service().await;
+    // Initialize store
+    let store = get_store().await;
 
     // Run the Lambda function
     //
@@ -24,14 +24,14 @@ async fn main() -> Result<(), E> {
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
-    // pass a service to a lambda function.
+    // pass a store to a lambda function.
     //
     // Furthermore, we don't await the result of `get_product` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
     lambda_runtime::run(handler(|event: Request, ctx: Context| {
-        get_product(&service, event, ctx)
+        get_product(&store, event, ctx)
     }))
     .await?;
     Ok(())

--- a/src/bin/lambda/get-products.rs
+++ b/src/bin/lambda/get-products.rs
@@ -12,8 +12,8 @@ async fn main() -> Result<(), E> {
     // Initialize logger
     setup_tracing();
 
-    // Initialize service
-    let service = get_crud_service().await;
+    // Initialize store
+    let store = get_store().await;
 
     // Run the Lambda function
     //
@@ -24,14 +24,14 @@ async fn main() -> Result<(), E> {
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
-    // pass a service to a lambda function.
+    // pass a store to a lambda function.
     //
     // Furthermore, we don't await the result of `get_products` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
     lambda_runtime::run(handler(|event: Request, ctx: Context| {
-        get_products(&service, event, ctx)
+        get_products(&store, event, ctx)
     }))
     .await?;
     Ok(())

--- a/src/bin/lambda/put-product.rs
+++ b/src/bin/lambda/put-product.rs
@@ -12,8 +12,8 @@ async fn main() -> Result<(), E> {
     // Initialize logger
     setup_tracing();
 
-    // Initialize service
-    let service = get_crud_service().await;
+    // Initialize store
+    let store = get_store().await;
 
     // Run the Lambda function
     //
@@ -24,14 +24,14 @@ async fn main() -> Result<(), E> {
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
-    // pass a service to a lambda function.
+    // pass a store to a lambda function.
     //
     // Furthermore, we don't await the result of `put_product` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
     lambda_runtime::run(handler(|event: Request, ctx: Context| {
-        put_product(&service, event, ctx)
+        put_product(&store, event, ctx)
     }))
     .await?;
     Ok(())

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,0 +1,31 @@
+//! Domain logic for the application.
+
+use crate::{
+    error::Error,
+    event_bus::EventBus,
+    model::{Event, Product, ProductRange},
+    store::{StoreDelete, StoreGet, StoreGetAll, StorePut},
+};
+
+pub async fn get_products(
+    store: &dyn StoreGetAll,
+    next: Option<&str>,
+) -> Result<ProductRange, Error> {
+    store.all(next).await
+}
+
+pub async fn get_product(store: &dyn StoreGet, id: &str) -> Result<Option<Product>, Error> {
+    store.get(id).await
+}
+
+pub async fn put_product(store: &dyn StorePut, product: &Product) -> Result<(), Error> {
+    store.put(product).await
+}
+
+pub async fn delete_product(store: &dyn StoreDelete, id: &str) -> Result<(), Error> {
+    store.delete(id).await
+}
+
+pub async fn send_events(event_bus: &dyn EventBus<E = Event>, events: &[Event]) -> Result<(), Error> {
+    event_bus.send_events(events).await
+}

--- a/src/entrypoints/lambda/apigateway.rs
+++ b/src/entrypoints/lambda/apigateway.rs
@@ -1,4 +1,4 @@
-use crate::{Product, CrudService};
+use crate::{domain, store, Product};
 use lambda_http::{
     ext::RequestExt, lambda_runtime::Context, Body, IntoResponse, Request, Response,
 };
@@ -8,9 +8,9 @@ use tracing::{error, info, instrument, warn};
 type E = Box<dyn std::error::Error + Sync + Send + 'static>;
 
 /// Delete a product
-#[instrument(skip(service))]
+#[instrument(skip(store))]
 pub async fn delete_product(
-    service: &CrudService,
+    store: &dyn store::StoreDelete,
     event: Request,
     _: Context,
 ) -> Result<impl IntoResponse, E> {
@@ -31,7 +31,7 @@ pub async fn delete_product(
 
     // Delete product
     info!("Deleting product {}", id);
-    let res = service.delete_product(id).await;
+    let res = domain::delete_product(store, id).await;
 
     // Return response
     //
@@ -58,9 +58,9 @@ pub async fn delete_product(
 }
 
 /// Get a product
-#[instrument(skip(service))]
+#[instrument(skip(store))]
 pub async fn get_product(
-    service: &CrudService,
+    store: &dyn store::StoreGet,
     event: Request,
     _: Context,
 ) -> Result<impl IntoResponse, E> {
@@ -81,7 +81,7 @@ pub async fn get_product(
 
     // Retrieve product
     info!("Fetching product {}", id);
-    let product = service.get_product(id).await;
+    let product = domain::get_product(store, id).await;
 
     // Return response
     //
@@ -108,15 +108,15 @@ pub async fn get_product(
 }
 
 /// Retrieve products
-#[instrument(skip(service))]
+#[instrument(skip(store))]
 pub async fn get_products(
-    service: &CrudService,
+    store: &dyn store::StoreGetAll,
     _event: Request,
     _: Context,
 ) -> Result<impl IntoResponse, E> {
     // Retrieve products
     // TODO: Add pagination
-    let res = service.get_products(None).await;
+    let res = domain::get_products(store, None).await;
 
     // Return response
     Ok(match res {
@@ -134,9 +134,9 @@ pub async fn get_products(
 }
 
 /// Put a product
-#[instrument(skip(service))]
+#[instrument(skip(store))]
 pub async fn put_product(
-    service: &CrudService,
+    store: &dyn store::StorePut,
     event: Request,
     _: Context,
 ) -> Result<impl IntoResponse, E> {
@@ -194,7 +194,7 @@ pub async fn put_product(
     }
 
     // Put product
-    let res = service.put_product(&product).await;
+    let res = domain::put_product(store, &product).await;
 
     // Return response
     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! # Domain logic for the service
 
+pub mod domain;
 pub mod entrypoints;
 mod error;
 pub mod event_bus;
@@ -10,61 +11,16 @@ pub mod utils;
 pub use error::Error;
 use event_bus::EventBus;
 pub use model::{Event, Product, ProductRange};
-use store::Store;
-
-/// CRUD Service
-/// 
-/// This service handles CRUD operations for products.
-/// 
-/// Since this only fetches and return data from DynamoDB, the functions here
-/// are very simple. They just fetch the data from the store and return it.
-/// 
-/// In a real application, you would probably want to add some business logic
-/// here, such as validating the data, or adding additional data to the response.
-pub struct CrudService {
-    store: Box<dyn Store + Send + Sync>,
-}
-
-impl CrudService {
-    pub fn new(
-        store: Box<dyn Store + Send + Sync>,
-    ) -> Self {
-        Self { store }
-    }
-
-    // Get a product by its ID
-    pub async fn get_product(&self, id: &str) -> Result<Option<Product>, Error> {
-        self.store.get(id).await
-    }
-
-    // Get a list of products
-    pub async fn get_products(&self, next: Option<&str>) -> Result<ProductRange, Error> {
-        self.store.all(next).await
-    }
-
-    // Create or update product
-    pub async fn put_product(&self, product: &Product) -> Result<(), Error> {
-        self.store.put(product).await
-    }
-
-    // Delete a product
-    pub async fn delete_product(&self, id: &str) -> Result<(), Error> {
-        self.store.delete(id).await
-    }
-}
-
 
 /// Event Service
-/// 
+///
 /// This service takes events and publishes them to the event bus.
 pub struct EventService {
     event_bus: Box<dyn EventBus<E = Event> + Send + Sync>,
 }
 
 impl EventService {
-    pub fn new(
-        event_bus: Box<dyn EventBus<E = Event> + Send + Sync>,
-    ) -> Self {
+    pub fn new(event_bus: Box<dyn EventBus<E = Event> + Send + Sync>) -> Self {
         Self { event_bus }
     }
 

--- a/src/store/dynamodb/mod.rs
+++ b/src/store/dynamodb/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Store implementation using the AWS SDK for DynamoDB.
 
-use super::Store;
+use super::{Store, StoreDelete, StoreGet, StoreGetAll, StorePut};
 use crate::{Error, Product, ProductRange};
 use async_trait::async_trait;
 use aws_sdk_dynamodb::{model::AttributeValue, Client};
@@ -31,8 +31,10 @@ where
     }
 }
 
+impl<C> Store for DynamoDBStore<C> where C: aws_smithy_client::bounds::SmithyConnector {}
+
 #[async_trait]
-impl<C> Store for DynamoDBStore<C>
+impl<C> StoreGetAll for DynamoDBStore<C>
 where
     C: aws_smithy_client::bounds::SmithyConnector,
 {
@@ -60,6 +62,13 @@ where
         let next = res.last_evaluated_key.map(|m| m.get_s("id").unwrap());
         Ok(ProductRange { products, next })
     }
+}
+
+#[async_trait]
+impl<C> StoreGet for DynamoDBStore<C>
+where
+    C: aws_smithy_client::bounds::SmithyConnector,
+{
     /// Get item
     #[instrument(skip(self))]
     async fn get(&self, id: &str) -> Result<Option<Product>, Error> {
@@ -77,6 +86,13 @@ where
             None => None,
         })
     }
+}
+
+#[async_trait]
+impl<C> StorePut for DynamoDBStore<C>
+where
+    C: aws_smithy_client::bounds::SmithyConnector,
+{
     /// Create or update an item
     #[instrument(skip(self))]
     async fn put(&self, product: &Product) -> Result<(), Error> {
@@ -90,6 +106,13 @@ where
 
         Ok(())
     }
+}
+
+#[async_trait]
+impl<C> StoreDelete for DynamoDBStore<C>
+where
+    C: aws_smithy_client::bounds::SmithyConnector,
+{
     /// Delete item
     #[instrument(skip(self))]
     async fn delete(&self, id: &str) -> Result<(), Error> {

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -4,7 +4,7 @@
 //! used in production, but rather as a simple implementation for local
 //! testing purposes.
 
-use super::Store;
+use super::{Store, StoreDelete, StoreGet, StoreGetAll, StorePut};
 use crate::{Error, Product, ProductRange};
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -21,8 +21,10 @@ impl MemoryStore {
     }
 }
 
+impl Store for MemoryStore {}
+
 #[async_trait]
-impl Store for MemoryStore {
+impl StoreGetAll for MemoryStore {
     async fn all(&self, _: Option<&str>) -> Result<ProductRange, Error> {
         Ok(ProductRange {
             products: self
@@ -35,11 +37,17 @@ impl Store for MemoryStore {
             next: None,
         })
     }
+}
 
+#[async_trait]
+impl StoreGet for MemoryStore {
     async fn get(&self, id: &str) -> Result<Option<Product>, Error> {
         Ok(self.data.read().unwrap().get(id).cloned())
     }
+}
 
+#[async_trait]
+impl StorePut for MemoryStore {
     async fn put(&self, product: &Product) -> Result<(), Error> {
         self.data
             .write()
@@ -47,7 +55,10 @@ impl Store for MemoryStore {
             .insert(product.id.clone(), product.clone());
         Ok(())
     }
+}
 
+#[async_trait]
+impl StoreDelete for MemoryStore {
     async fn delete(&self, id: &str) -> Result<(), Error> {
         self.data.write().unwrap().remove(id);
         Ok(())
@@ -57,7 +68,7 @@ impl Store for MemoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Error, Store};
+    use crate::Error;
 
     struct ConstProduct<'a> {
         id: &'a str,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,14 +7,35 @@ mod memory;
 pub use dynamodb::DynamoDBStore;
 pub use memory::MemoryStore;
 
-// Trait for data storage
-//
-// This trait is implemented by the different storage backends. It provides
-// the basic interface for storing and retrieving products.
+pub trait Store: StoreGetAll + StoreGet + StorePut + StoreDelete {}
+
+/// Trait for retrieving all products
+///
+/// This trait is implemented by the different storage backends. It provides
+/// the basic interface for retrieving all products.
+///
+/// A given store could return only a partial list of all the products. If
+/// this is the case, the `next` parameter should be used to retrieve the
+/// next page of products.
 #[async_trait]
-pub trait Store {
+pub trait StoreGetAll: Send + Sync {
     async fn all(&self, next: Option<&str>) -> Result<ProductRange, Error>;
+}
+
+/// Trait for retrieving a single product
+#[async_trait]
+pub trait StoreGet: Send + Sync {
     async fn get(&self, id: &str) -> Result<Option<Product>, Error>;
+}
+
+/// Trait for storing a single product
+#[async_trait]
+pub trait StorePut: Send + Sync {
     async fn put(&self, product: &Product) -> Result<(), Error>;
+}
+
+/// Trait for deleting a single product
+#[async_trait]
+pub trait StoreDelete: Send + Sync {
     async fn delete(&self, id: &str) -> Result<(), Error>;
 }


### PR DESCRIPTION
This pull request implements fine-grained traits for the `products::store` port.

## Current situation

The current implementation uses a single trait for `products::store::Store`, which is then stored in a `Box<dyn Store>` in a `products::CrudService`. Because of that, all Lambda functions behind API Gateway have references to all the functions implemented by the `Store` trait.

By running `make build && grep 'Scanning DynamoDB table' build/*/bootstrap` on the current main branch, I get the following results:

```
Binary file build/delete-product/bootstrap matches
Binary file build/get-product/bootstrap matches
Binary file build/get-products/bootstrap matches
Binary file build/put-product/bootstrap matches
```

That means that whenever there is a code change for  the `all()` function for DynamoDBStore, all four Lambda functions will be updated.

## New implementation

By running the same command, I only get a single match from the Lambda functions, meaning that the other ones no longer have code for functions that will never be called.

```
Binary file build/get-products/bootstrap matches
```

I can confirm that functions are the same by comparing the hash of all binaries after a small code change on `products::store::dynamodb::DynamoDBStore`'s implementation of `all()` (using `sha256sum build/*/bootstrap` after a `make build`).

Before:

```
6aee8a97d7a5a5abffb9e25f115044bbb332106e17b8c3f0b40b50e09d3e9c71  build/delete-product/bootstrap
732583b13f6dfe276cbffdad3ce0d0348652d809b2bb2168d9e8f0eb455aa217  build/dynamodb-streams/bootstrap
0eef074bcbd7aeac62869cea4f244a0743f8b73eb9df1ecafea97d28354712a5  build/get-product/bootstrap
d5fce4d479ff96ed732ca1f1315e5b5d17bb31562b664558bc8970a984f61737  build/get-products/bootstrap
7c13ffb616d4b4d4369f17aec806097afd0ae59f773675f253024adcfca2f7e1  build/put-product/bootstrap
```

After:

```
6aee8a97d7a5a5abffb9e25f115044bbb332106e17b8c3f0b40b50e09d3e9c71  build/delete-product/bootstrap
732583b13f6dfe276cbffdad3ce0d0348652d809b2bb2168d9e8f0eb455aa217  build/dynamodb-streams/bootstrap
0eef074bcbd7aeac62869cea4f244a0743f8b73eb9df1ecafea97d28354712a5  build/get-product/bootstrap
30bab1eaae8923f0b4c5732906a6872def7234d11d3f35f7f013393fc586879a  build/get-products/bootstrap
7c13ffb616d4b4d4369f17aec806097afd0ae59f773675f253024adcfca2f7e1  build/put-product/bootstrap
```

The only hash that changed is for `build/get-products/bootstrap`, as expected. Meaning that functions won't redeploy unless there is a code change that affected them.

As part of this change, I've also moved the domain logic layer to `src/domain.rs`. It's currently just functions until I implement a better interface, for example using extension traits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
