### PR TITLE
feat: update memory for DDB function to 128MB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -107,7 +107,6 @@ Resources:
       Environment:
         Variables:
           EVENT_BUS_NAME: !Ref EventBus
-      MemorySize: 3072
       Policies:
         - Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/serverless-rust-demo/issues/27

*Description of changes:* change memory to 128MB for DDB function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
