### PR TITLE
Use http status code constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a simple serverless application built in Rust. It consists of an API Gateway backed by four Lambda functions and a DynamoDB table for storage.
 
-This single crate will create [five different binaries](./src/bin), one for each Lambda function. It uses an [hexagonal architecture pattern](https://aws.amazon.com/blogs/compute/developing-evolutionary-architecture-with-aws-lambda/) to decouple the [entry points](./src/bin), from the main [domain logic](./src/lib.rs), the [storage component](./src/store), and the [event bus component](./src/event_bus).
+This single crate will create [five different binaries](./src/bin), one for each Lambda function. It uses an [hexagonal architecture pattern](https://aws.amazon.com/blogs/compute/developing-evolutionary-architecture-with-aws-lambda/) to decouple the [entry points](./src/entrypoints/), from the main [domain logic](./src/lib.rs), the [storage component](./src/store), and the [event bus component](./src/event_bus).
 
 ### Code walkthrough
 

--- a/src/bin/lambda/dynamodb-streams.rs
+++ b/src/bin/lambda/dynamodb-streams.rs
@@ -16,14 +16,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     //
     // This is the entry point for the Lambda function. The `lambda_runtime`
     // crate will take care of contacting the Lambda runtime API and invoking
-    // the `delete_product` function.
+    // the `parse_events` function.
     // See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
     //
     // This uses a closure to pass the Service without having to reinstantiate
     // it for every call. This is a bit of a hack, but it's the only way to
     // pass the event bus to a lambda function.
     //
-    // Furthermore, we don't await the result of `delete_product` because
+    // Furthermore, we don't await the result of `parse_events` because
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290

--- a/src/store/dynamodb/ext.rs
+++ b/src/store/dynamodb/ext.rs
@@ -14,7 +14,7 @@ pub trait AttributeValuesExt {
 }
 
 impl AttributeValuesExt for HashMap<String, AttributeValue> {
-    /// Return a string from an key
+    /// Return a string from a key
     ///
     /// E.g. if you run `get_s("id")` on a DynamoDB item structured like this,
     /// you will retrieve the value `"foo"`.
@@ -30,7 +30,7 @@ impl AttributeValuesExt for HashMap<String, AttributeValue> {
         Some(self.get(key)?.as_s().ok()?.to_owned())
     }
 
-    /// Return a number from an key
+    /// Return a number from a key
     ///
     /// E.g. if you run `get_n("price")` on a DynamoDB item structured like this,
     /// you will retrieve the value `10.0`.


### PR DESCRIPTION
*Description of changes:*

This changes the api gateway lambda entrypoints to use http status code constants from [http](https://lib.rs/crates/http) instead of literals. No functional change, but I think it increases readability and reduces risk of errors and the cognitive load (I don't have to know what e.g. status code `201' means) when using the constants.

This also included some typo fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
