### PR TITLE
chore: switch to zigbuild for cross compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This single crate will create [five different binaries](./src/bin), one for each
 ### Requirements
 
 * [Rust](https://www.rust-lang.org/) 1.56.0 or higher
-* [Cross](https://github.com/rust-embedded/cross) for cross-compilation to Arm64
+* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
+* [jq](https://stedolan.github.io/jq/) for tooling specific to this project
 * The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) 1.33.0 or higher for deploying to the cloud
 * [Artillery](https://artillery.io/) for load-testing the application
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Switch from `cross` to `zigbuild` for cross-compilation. As zigbuild doesn't depend on Docker, this should help with cross compilation from M1 macs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
