### PR TITLE
chore: bump lambda runtime to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ aws-smithy-client = { version = "0.36", features = ["test-util"] }
 aws-smithy-http = "0.36"
 aws-types = "0.6"
 futures = { version = "0.3", features = ["std"] }
-lambda_runtime = { version = "0.4", optional = true }
-lambda_http = { version = "0.4", optional = true }
+lambda_runtime = { version = "0.5", optional = true }
+lambda_http = { version = "0.5", optional = true }
 rayon = { version = "1.5", optional = true }
 serde = "1"
 serde_json = "1.0"

--- a/src/bin/lambda/delete-product.rs
+++ b/src/bin/lambda/delete-product.rs
@@ -1,8 +1,4 @@
-use lambda_http::{
-    handler,
-    lambda_runtime::{self, Context},
-    Request,
-};
+use lambda_http::{service_fn, Request, RequestExt};
 use products::{entrypoints::lambda::apigateway::delete_product, utils::*};
 
 #[tokio::main]
@@ -15,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
 
     // Run the Lambda function
     //
-    // This is the entry point for the Lambda function. The `lambda_runtime`
+    // This is the entry point for the Lambda function. The `lambda_http`
     // crate will take care of contacting the Lambda runtime API and invoking
     // the `delete_product` function.
     // See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
@@ -28,7 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_runtime::run(handler(|event: Request, ctx: Context| {
+    lambda_http::run(service_fn(|event: Request| {
+        let ctx = event.lambda_context();
         delete_product(&store, event, ctx)
     }))
     .await?;

--- a/src/bin/lambda/dynamodb-streams.rs
+++ b/src/bin/lambda/dynamodb-streams.rs
@@ -1,4 +1,4 @@
-use lambda_runtime::{handler_fn, Context};
+use lambda_runtime::{service_fn, LambdaEvent};
 use products::{
     entrypoints::lambda::dynamodb::{model::DynamoDBEvent, parse_events},
     utils::*,
@@ -27,7 +27,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_runtime::run(handler_fn(|event: DynamoDBEvent, ctx: Context| {
+    lambda_runtime::run(service_fn(|event: LambdaEvent<DynamoDBEvent>| {
+        let (event, ctx) = event.into_parts();
         parse_events(&event_bus, event, ctx)
     }))
     .await?;

--- a/src/bin/lambda/get-product.rs
+++ b/src/bin/lambda/get-product.rs
@@ -1,8 +1,4 @@
-use lambda_http::{
-    handler,
-    lambda_runtime::{self, Context},
-    Request,
-};
+use lambda_http::{service_fn, Request, RequestExt};
 use products::{entrypoints::lambda::apigateway::get_product, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -17,7 +13,7 @@ async fn main() -> Result<(), E> {
 
     // Run the Lambda function
     //
-    // This is the entry point for the Lambda function. The `lambda_runtime`
+    // This is the entry point for the Lambda function. The `lambda_http`
     // crate will take care of contacting the Lambda runtime API and invoking
     // the `get_product` function.
     // See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
@@ -30,7 +26,8 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_runtime::run(handler(|event: Request, ctx: Context| {
+    lambda_http::run(service_fn(|event: Request| {
+        let ctx = event.lambda_context();
         get_product(&store, event, ctx)
     }))
     .await?;

--- a/src/bin/lambda/get-products.rs
+++ b/src/bin/lambda/get-products.rs
@@ -1,8 +1,4 @@
-use lambda_http::{
-    handler,
-    lambda_runtime::{self, Context},
-    Request,
-};
+use lambda_http::{service_fn, Request, RequestExt};
 use products::{entrypoints::lambda::apigateway::get_products, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -17,7 +13,7 @@ async fn main() -> Result<(), E> {
 
     // Run the Lambda function
     //
-    // This is the entry point for the Lambda function. The `lambda_runtime`
+    // This is the entry point for the Lambda function. The `lambda_http`
     // crate will take care of contacting the Lambda runtime API and invoking
     // the `get_products` function.
     // See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
@@ -30,7 +26,8 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_runtime::run(handler(|event: Request, ctx: Context| {
+    lambda_http::run(service_fn(|event: Request| {
+        let ctx = event.lambda_context();
         get_products(&store, event, ctx)
     }))
     .await?;

--- a/src/bin/lambda/put-product.rs
+++ b/src/bin/lambda/put-product.rs
@@ -1,8 +1,4 @@
-use lambda_http::{
-    handler,
-    lambda_runtime::{self, Context},
-    Request,
-};
+use lambda_http::{service_fn, Request, RequestExt};
 use products::{entrypoints::lambda::apigateway::put_product, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -17,7 +13,7 @@ async fn main() -> Result<(), E> {
 
     // Run the Lambda function
     //
-    // This is the entry point for the Lambda function. The `lambda_runtime`
+    // This is the entry point for the Lambda function. The `lambda_http`
     // crate will take care of contacting the Lambda runtime API and invoking
     // the `put_product` function.
     // See https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
@@ -30,7 +26,8 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_runtime::run(handler(|event: Request, ctx: Context| {
+    lambda_http::run(service_fn(|event: Request| {
+        let ctx = event.lambda_context();
         put_product(&store, event, ctx)
     }))
     .await?;

--- a/src/entrypoints/lambda/apigateway.rs
+++ b/src/entrypoints/lambda/apigateway.rs
@@ -19,7 +19,7 @@ pub async fn delete_product(
     //
     // If the event doesn't contain a product ID, we return a 400 Bad Request.
     let path_parameters = event.path_parameters();
-    let id = match path_parameters.get("id") {
+    let id = match path_parameters.first("id") {
         Some(id) => id,
         None => {
             warn!("Missing 'id' parameter in path");
@@ -69,7 +69,7 @@ pub async fn get_product(
     //
     // If the event doesn't contain a product ID, we return a 400 Bad Request.
     let path_parameters = event.path_parameters();
-    let id = match path_parameters.get("id") {
+    let id = match path_parameters.first("id") {
         Some(id) => id,
         None => {
             warn!("Missing 'id' parameter in path");
@@ -148,7 +148,7 @@ pub async fn put_product(
     //
     // If the event doesn't contain a product ID, we return a 400 Bad Request.
     let path_parameters = event.path_parameters();
-    let id = match path_parameters.get("id") {
+    let id = match path_parameters.first("id") {
         Some(id) => id,
         None => {
             warn!("Missing 'id' parameter in path");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump `lambda_http` and `lambda_runtime` to v0.5.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
