### PR TITLE
feat: use event.payload() for API entrypoints

### DIFF
--- a/src/bin/lambda/delete-product.rs
+++ b/src/bin/lambda/delete-product.rs
@@ -1,4 +1,4 @@
-use lambda_http::{service_fn, Request, RequestExt};
+use lambda_http::{service_fn, Request};
 use products::{entrypoints::lambda::apigateway::delete_product, utils::*};
 
 #[tokio::main]
@@ -24,10 +24,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_http::run(service_fn(|event: Request| {
-        let ctx = event.lambda_context();
-        delete_product(&store, event, ctx)
-    }))
-    .await?;
+    lambda_http::run(service_fn(|event: Request| delete_product(&store, event))).await?;
     Ok(())
 }

--- a/src/bin/lambda/get-product.rs
+++ b/src/bin/lambda/get-product.rs
@@ -1,4 +1,4 @@
-use lambda_http::{service_fn, Request, RequestExt};
+use lambda_http::{service_fn, Request};
 use products::{entrypoints::lambda::apigateway::get_product, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -26,10 +26,6 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_http::run(service_fn(|event: Request| {
-        let ctx = event.lambda_context();
-        get_product(&store, event, ctx)
-    }))
-    .await?;
+    lambda_http::run(service_fn(|event: Request| get_product(&store, event))).await?;
     Ok(())
 }

--- a/src/bin/lambda/get-products.rs
+++ b/src/bin/lambda/get-products.rs
@@ -1,4 +1,4 @@
-use lambda_http::{service_fn, Request, RequestExt};
+use lambda_http::{service_fn, Request};
 use products::{entrypoints::lambda::apigateway::get_products, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -26,10 +26,6 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_http::run(service_fn(|event: Request| {
-        let ctx = event.lambda_context();
-        get_products(&store, event, ctx)
-    }))
-    .await?;
+    lambda_http::run(service_fn(|event: Request| get_products(&store, event))).await?;
     Ok(())
 }

--- a/src/bin/lambda/put-product.rs
+++ b/src/bin/lambda/put-product.rs
@@ -1,4 +1,4 @@
-use lambda_http::{service_fn, Request, RequestExt};
+use lambda_http::{service_fn, Request};
 use products::{entrypoints::lambda::apigateway::put_product, utils::*};
 
 type E = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -26,10 +26,6 @@ async fn main() -> Result<(), E> {
     // async closures aren't stable yet. This way, the closure returns a Future,
     // which matches the signature of the lambda function.
     // See https://github.com/rust-lang/rust/issues/62290
-    lambda_http::run(service_fn(|event: Request| {
-        let ctx = event.lambda_context();
-        put_product(&store, event, ctx)
-    }))
-    .await?;
+    lambda_http::run(service_fn(|event: Request| put_product(&store, event))).await?;
     Ok(())
 }

--- a/tests/aws_test.rs
+++ b/tests/aws_test.rs
@@ -123,7 +123,10 @@ async fn test_put_product_empty() -> Result<(), E> {
     println!("PUT new product");
     let res = client.put(format!("{}/empty-id", api_url)).send().await?;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
-    assert!(res.text().await?.contains("Empty request body"));
+    assert!(res
+        .text()
+        .await?
+        .contains("Missing product in request body"));
 
     Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/431#issuecomment-1046797817

*Description of changes:*

Use `event.payload()` for API entrypoints instead of manually deserializing the payload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
