### PR TITLE
Use cargo-lambda to build binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 ifeq (,$(shell which zig))
 	$(error "Could not found Zig compiler, please install it")
 endif
-	cargo install cargo-zigbuild
+	cargo install cargo-lambda
 ifeq (,$(shell which sam))
 	$(error "Could not found SAM CLI, please install it")
 endif
@@ -28,21 +28,7 @@ ifeq (,$(shell which artillery))
 endif
 
 build:
-ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
-	@echo "Same host and target. Using native build"
-	cargo build --release --target $(ARCH)
-else
-	@echo "Different host and target. Using zigbuild"
-	cargo zigbuild --release --target $(ARCH)
-endif
-	
-	rm -rf ./build
-	mkdir -p ./build
-	${MAKE} ${MAKEOPTS} $(foreach function,${FUNCTIONS}, build-${function})
-
-build-%:
-	mkdir -p ./build/$*
-	cp -v ./target/$(ARCH)/release/$* ./build/$*/bootstrap
+	cargo lambda build --release --target $(ARCH)
 
 deploy:
 	if [ -f samconfig.toml ]; \

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This single crate will create [five different binaries](./src/bin), one for each
 ### Requirements
 
 * [Rust](https://www.rust-lang.org/) 1.56.0 or higher
-* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
-* [jq](https://stedolan.github.io/jq/) for tooling specific to this project
+* [cargo-lambda](https://github.com/calavera/cargo-lambda)
+* [Zig](https://ziglang.org/) for cross-compilation (cargo-lambda will prompt you to install it if it's missing in your host system)
 * The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) 1.33.0 or higher for deploying to the cloud
 * [Artillery](https://artillery.io/) for load-testing the application
 

--- a/template.yaml
+++ b/template.yaml
@@ -18,7 +18,7 @@ Resources:
   GetProductsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/get-products/
+      CodeUri: target/lambda/get-products/
       Events:
         Api:
           Type: HttpApi
@@ -37,7 +37,7 @@ Resources:
   GetProductFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/get-product/
+      CodeUri: target/lambda/get-product/
       Events:
         Api:
           Type: HttpApi
@@ -56,7 +56,7 @@ Resources:
   PutProductFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/put-product/
+      CodeUri: target/lambda/put-product/
       Events:
         Api:
           Type: HttpApi
@@ -75,7 +75,7 @@ Resources:
   DeleteProductFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/delete-product/
+      CodeUri: target/lambda/delete-product/
       Events:
         Api:
           Type: HttpApi
@@ -94,7 +94,7 @@ Resources:
   DDBStreamsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/dynamodb-streams/
+      CodeUri: target/lambda/dynamodb-streams/
       Timeout: 10
       Events:
         TableStream:


### PR DESCRIPTION
This Cargo subcommand abstracts away most of the boilerplate necessary to work with zigbuild and organize binaries.

You can see more information in the links below:

https://crates.io/crates/cargo-lambda
https://github.com/calavera/cargo-lambda

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
