### PR TITLE
Changes to AL2023 runtime

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Globals:
     MemorySize: 128
     Architectures: ["arm64"]
     Handler: bootstrap
-    Runtime: provided.al2
+    Runtime: provided.al2023
     Timeout: 5
     Tracing: Active
     Environment:


### PR DESCRIPTION
This helps to fix the failures I was getting about missing GLIBC_2.28 which is no longer available on al2

Reference: https://github.com/awslabs/aws-lambda-rust-runtime/issues/874

The lambdas were failing (500) throwing exception:

```
/var/task/bootstrap: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /var/task/bootstrap)
```